### PR TITLE
Fix SpatioTemporalSparseCVI and add spatiotemporal tests

### DIFF
--- a/markovflow/models/spatio_temporal_variational.py
+++ b/markovflow/models/spatio_temporal_variational.py
@@ -430,16 +430,14 @@ class SpatioTemporalSparseCVI(SpatioTemporalBase):
         self.nat1 = Parameter(zeros1)
         self.nat2 = Parameter(zeros2)
 
-        self._posterior = ConditionalProcess(
+    @property
+    def posterior(self) -> PosteriorProcess:
+        """ Posterior object to predict outside of the training time points """
+        return ConditionalProcess(
             posterior_dist=self.dist_q,
             kernel=self.kernel,
             conditioning_time_points=self.inducing_time,
         )
-
-    @property
-    def posterior(self) -> PosteriorProcess:
-        """ Posterior object to predict outside of the training time points """
-        return self._posterior
 
     @property
     def dist_q(self) -> StateSpaceModel:

--- a/tests/integration/models/test_spatio_temporal_variational.py
+++ b/tests/integration/models/test_spatio_temporal_variational.py
@@ -72,6 +72,10 @@ def _setup_gpr_model_fixture(st_data):
 
 
 def test_spatiotemporalsparsevariational(st_model_params, gpr_model, st_data):
+    """
+    Test that `SpatioTemporalSparseVariational` trained on data at the inducing points
+    evaluated at the inducing points gives the same ELBO and predicted mean as `GPR`.
+    """
     st_model = SpatioTemporalSparseVariational(**st_model_params)
     assert isinstance(st_model, SpatioTemporalBase)
     for t in (
@@ -107,6 +111,10 @@ def test_spatiotemporalsparsevariational(st_model_params, gpr_model, st_data):
 
 
 def test_spatiotemporalsparsecvi(st_model_params, gpr_model, st_data):
+    """
+    Test that `SpatioTemporalSparseCVI` trained on data at the inducing points
+    evaluated at the inducing points gives the same ELBO and predicted mean as `GPR`.
+    """
     st_model = SpatioTemporalSparseCVI(**st_model_params, learning_rate=1.0)
     assert isinstance(st_model, SpatioTemporalBase)
     true_likelihood = gpr_model.log_marginal_likelihood()

--- a/tests/integration/models/test_spatio_temporal_variational.py
+++ b/tests/integration/models/test_spatio_temporal_variational.py
@@ -83,7 +83,7 @@ def test_spatiotemporalsparsevariational(st_model_params, gpr_model, st_data):
 
     true_likelihood = gpr_model.log_marginal_likelihood()
 
-    opt = tf.optimizers.Adam(learning_rate=1e-2)
+    opt = tf.optimizers.Adam(learning_rate=1e-1)
 
     @tf.function
     def opt_step(data):


### PR DESCRIPTION
This PR fixes #22

As suggested by @vincentadam87 in https://github.com/secondmind-labs/markovflow/issues/22#issuecomment-1269856451, it also adds integration tests comparing the elbo of the variational model against the log-likelihood of `GPR`. It also checks that the predicted means are the same (predicted variances do not agree; should they?)