### PR TITLE
Don't hardcode float64 in BlockTriDiagonal

### DIFF
--- a/markovflow/block_tri_diag.py
+++ b/markovflow/block_tri_diag.py
@@ -217,7 +217,7 @@ class BlockTriDiagonal(abc.ABC):
             )
         else:
             shape = tf.concat([self.batch_shape, [1, self.inner_dim, self.inner_dim]], axis=0)
-            padding_zeros = tf.zeros(shape, dtype=tf.float64)
+            padding_zeros = tf.zeros(shape, dtype=self._sub_diag.dtype)
             # [... outer_dim, inner_dim, state_dim]
             padded_sub_diag = tf.concat([self._sub_diag, padding_zeros], axis=-3)
             transposed = list(map(tf.linalg.matrix_transpose, [(self._diag), padded_sub_diag]))


### PR DESCRIPTION
Currently  if we use parameters and data with a `float32` eltype, `update_sites` with `SpatioTemporalSparseCVI` fails because the `_convert_to_band` method of `BlockTriDiagonal` initializes a tensor with a dtype of `float64`. This PR changes the behavior to use the dtype of a user-provided variable. If the user is using `float32`, then this method now uses `float32`, and no error is thrown.