### PR TITLE
Support for priors on parameters

### DIFF
--- a/markovflow/gauss_markov.py
+++ b/markovflow/gauss_markov.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 from typing import Tuple
 
 import tensorflow as tf
+import gpflow
 
 from markovflow.base import SampleShape
 from markovflow.block_tri_diag import SymmetricBlockTriDiagonal
@@ -25,7 +26,7 @@ from markovflow.utils import tf_scope_class_decorator
 
 
 @tf_scope_class_decorator
-class GaussMarkovDistribution(tf.Module, ABC):
+class GaussMarkovDistribution(gpflow.Module, ABC):
     """
     Abstract class for representing a Gauss-Markov chain. Classes that extend this one (such as
     :class:`~markovflow.state_space_model.StateSpaceModel`) represent a different parameterisation

--- a/markovflow/kalman_filter.py
+++ b/markovflow/kalman_filter.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 import tensorflow as tf
+import gpflow
 from gpflow import default_float
 from gpflow.base import TensorType
 
@@ -28,7 +29,7 @@ from markovflow.state_space_model import StateSpaceModel
 from markovflow.utils import tf_scope_class_decorator
 
 
-class BaseKalmanFilter(tf.Module, ABC):
+class BaseKalmanFilter(gpflow.Module, ABC):
     r"""
     Performs a Kalman filter on a :class:`~markovflow.state_space_model.StateSpaceModel` and
     :class:`~markovflow.emission_model.EmissionModel`, with given observations.
@@ -334,7 +335,7 @@ class KalmanFilter(BaseKalmanFilter):
         )
         tf.debugging.assert_equal(tf.shape(observations), shape, message=message)
 
-        self._chol_obs_covariance = chol_obs_covariance  # To collect tf.Module trainables
+        self._chol_obs_covariance = chol_obs_covariance  # To collect gpflow.Module trainables
         self._observations = observations  # batch_shape + [num_transitions + 1, output_dim]
 
     @property
@@ -352,7 +353,7 @@ class KalmanFilter(BaseKalmanFilter):
         return self._observations
 
 
-class GaussianSites(tf.Module, ABC):
+class GaussianSites(gpflow.Module, ABC):
     """
     This class is a wrapper around the parameters specifying multiple independent
     Gaussian distributions.

--- a/markovflow/kernels/kernel.py
+++ b/markovflow/kernels/kernel.py
@@ -18,12 +18,13 @@ import abc
 from abc import abstractmethod
 
 import tensorflow as tf
+import gpflow
 
 from markovflow.emission_model import EmissionModel
 from markovflow.gauss_markov import GaussMarkovDistribution
 
 
-class Kernel(tf.Module, abc.ABC):
+class Kernel(gpflow.Module, abc.ABC):
     r"""
     Abstract class generating a :class:`~markovflow.state_space_model.StateSpaceModel` for a
     given set of time points.

--- a/markovflow/likelihoods/likelihoods.py
+++ b/markovflow/likelihoods/likelihoods.py
@@ -25,7 +25,7 @@ import tensorflow as tf
 from markovflow.utils import tf_scope_fn_decorator
 
 
-class Likelihood(tf.Module, abc.ABC):
+class Likelihood(gpflow.Module, abc.ABC):
     """
     Abstract class for likelihoods.
 

--- a/markovflow/mean_function.py
+++ b/markovflow/mean_function.py
@@ -17,6 +17,7 @@
 import abc
 
 import tensorflow as tf
+import gpflow
 
 from markovflow.block_tri_diag import LowerTriangularBlockTriDiagonal
 from markovflow.kernels import SDEKernel
@@ -24,7 +25,7 @@ from markovflow.utils import tf_scope_class_decorator, to_delta_time
 
 
 @tf_scope_class_decorator
-class MeanFunction(tf.Module, abc.ABC):
+class MeanFunction(gpflow.Module, abc.ABC):
     """
     Abstract class for mean functions.
 

--- a/markovflow/models/gaussian_process_regression.py
+++ b/markovflow/models/gaussian_process_regression.py
@@ -71,7 +71,7 @@ class GaussianProcessRegression(MarkovFlowModel):
         # ensure that time_points have the shape: batch_shape + [num_data]
         tf.ensure_shape(time_points, observations.shape[:-1])
 
-        # To collect kernel and mean function tf.Module trainable_variables
+        # To collect kernel and mean function gpflow.Module trainable_variables
         self._kernel = kernel
         if mean_function is None:
             mean_function = ZeroMeanFunction(obs_dim=1)

--- a/markovflow/models/models.py
+++ b/markovflow/models/models.py
@@ -26,18 +26,20 @@ from abc import ABC, abstractmethod
 from typing import Tuple
 
 import tensorflow as tf
+import gpflow
 
 from markovflow.posterior import PosteriorProcess
 from markovflow.utils import tf_scope_class_decorator
 
 
-class MarkovFlowModel(tf.Module, ABC):
+class MarkovFlowModel(gpflow.Module, ABC):
     """
     Abstract class representing Markovflow models that depend on input data.
 
-    All Markovflow models are :class:`TensorFlow Modules <tf.Module>`, so it is possible to obtain
-    trainable variables via the :attr:`trainable_variables` attribute. You can combine this with
-    the :meth:`loss` method to train the model. For example::
+    All Markovflow models are :class:`GPflow Modules <gpflow.Module>`, so it is possible to obtain
+    trainable variables via the :attr:`trainable_variables` attribute and trainable parameters via
+    the :attr:`trainable_parameters` attribute. You can combine this with the :meth:`loss` method
+    to train the model. For example::
 
         optimizer = tf.compat.v1.train.AdamOptimizer(learning_rate=0.01)
         for i in range(iterations):
@@ -104,7 +106,7 @@ class MarkovFlowModel(tf.Module, ABC):
 
 
 @tf_scope_class_decorator
-class MarkovFlowSparseModel(tf.Module, ABC):
+class MarkovFlowSparseModel(gpflow.Module, ABC):
     """
     Abstract class representing Markovflow models that do not need to store the training
     data (:math:`X, Y`) in the model to approximate the

--- a/markovflow/models/models.py
+++ b/markovflow/models/models.py
@@ -54,6 +54,15 @@ class MarkovFlowModel(gpflow.Module, ABC):
        method and :attr:`posterior` attribute.
     """
 
+    def log_prior_density(self) -> tf.Tensor:
+        """
+        Sum of the log prior probability densities of all (constrained) variables in this model.
+        """
+        if self.trainable_parameters:
+            return tf.add_n([p.log_prior_density() for p in self.trainable_parameters])
+        else:
+            return tf.convert_to_tensor(0.0, gpflow.default_float())
+
     @abstractmethod
     def loss(self) -> tf.Tensor:
         """
@@ -129,6 +138,15 @@ class MarkovFlowSparseModel(gpflow.Module, ABC):
     .. note:: Markovflow models that extend this class must implement the :meth:`loss`
        method and :attr:`posterior` attribute.
     """
+
+    def log_prior_density(self) -> tf.Tensor:
+        """
+        Sum of the log prior probability densities of all (constrained) variables in this model.
+        """
+        if self.trainable_parameters:
+            return tf.add_n([p.log_prior_density() for p in self.trainable_parameters])
+        else:
+            return tf.convert_to_tensor(0.0, gpflow.default_float())
 
     @abstractmethod
     def loss(self, input_data: Tuple[tf.Tensor, tf.Tensor]) -> tf.Tensor:

--- a/markovflow/models/sparse_variational.py
+++ b/markovflow/models/sparse_variational.py
@@ -118,7 +118,7 @@ class SparseVariationalGaussianProcess(MarkovFlowSparseModel):
         super().__init__(self.__class__.__name__)
 
         self._num_data = num_data
-        self._kernel = kernel  # To collect tf.Module trainable_variables
+        self._kernel = kernel  # To collect gpflow.Module trainable_variables
         self._likelihood = likelihood
 
         if mean_function is None:
@@ -133,7 +133,7 @@ class SparseVariationalGaussianProcess(MarkovFlowSparseModel):
 
         # q will approximate the posterior after optimisation.
         # This needs to be an instance attribute to provide trainable variables
-        # when calling tf.Module trainable_variables. This is fine though, since
+        # when calling gpflow.Module trainable_variables. This is fine though, since
         # `GaussMarkovDistribution` doesn't do any computation in its initialiser.
         self._dist_q = initial_distribution.create_trainable_copy()
 

--- a/markovflow/models/sparse_variational_cvi.py
+++ b/markovflow/models/sparse_variational_cvi.py
@@ -125,7 +125,7 @@ class SparseCVIGaussianProcess(MarkovFlowSparseModel):
 
         # q will approximate the posterior after optimisation.
         # This needs to be an instance attribute to provide trainable variables
-        # when calling tf.Module trainable_variables. This is fine though, since
+        # when calling gpflow.Module trainable_variables. This is fine though, since
         # StateSpaceModel doesn't do any computation in its initialiser.
 
         # initialize sites

--- a/markovflow/models/variational.py
+++ b/markovflow/models/variational.py
@@ -98,7 +98,7 @@ class VariationalGaussianProcess(MarkovFlowModel):
         super().__init__(self.__class__.__name__)
         time_points, observations = input_data
 
-        # To collect kernel and mean function tf.Module trainable_variables
+        # To collect kernel and mean function gpflow.Module trainable_variables
         self._kernel = kernel
         if mean_function is None:
             mean_function = ZeroMeanFunction(obs_dim=1)
@@ -114,7 +114,7 @@ class VariationalGaussianProcess(MarkovFlowModel):
 
         # q will approximate the posterior after optimisation.
         # This needs to be an instance attribute to provide trainable variables
-        # when calling tf.Module trainable_variables. This is fine though, since
+        # when calling gpflow.Module trainable_variables. This is fine though, since
         # StateSpaceModel doesn't do any computation in its initialiser.
         self._dist_q = initial_distribution.create_trainable_copy()
 

--- a/markovflow/posterior.py
+++ b/markovflow/posterior.py
@@ -19,6 +19,7 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 import tensorflow as tf
+import gpflow
 from gpflow.likelihoods import Likelihood as GPF_Likelihood
 
 from markovflow.base import SampleShape
@@ -33,7 +34,7 @@ Likelihood = Union[MF_Likelihood, GPF_Likelihood]
 
 
 @tf_scope_class_decorator
-class PosteriorProcess(tf.Module, ABC):
+class PosteriorProcess(gpflow.Module, ABC):
     """
     Abstract class for forming a posterior process.
 

--- a/tests/integration/likelihoods/test_likelihoods.py
+++ b/tests/integration/likelihoods/test_likelihoods.py
@@ -17,6 +17,7 @@
 import numpy as np
 import pytest
 import tensorflow as tf
+import gpflow
 from gpflow.likelihoods import Gaussian
 
 from markovflow.likelihoods import MultivariateGaussian
@@ -38,6 +39,16 @@ def _setup_data(with_tf_random_seed, batch_shape):
     shape = tuple(list(batch_shape) + [num_data])
     f_covariances = generate_random_pos_def_matrix(obs_dim, shape)
     return f, f_covariances, observations
+
+
+def test_multivariate_gaussian_trainable_parameters():
+    """Check that MultivariateGaussian tracks its trainable_parameters."""
+    chol_covariance = np.eye(2)
+    mvngauss = MultivariateGaussian(chol_covariance=chol_covariance)
+    assert isinstance(mvngauss, gpflow.Module)
+    assert mvngauss.trainable_parameters == (mvngauss.chol_covariance,)
+    gpflow.set_trainable(mvngauss.chol_covariance, False)
+    assert mvngauss.trainable_parameters == ()
 
 
 def test_multivariate_gaussian_variational_expectations(data):

--- a/tests/unit/test_mean_function.py
+++ b/tests/unit/test_mean_function.py
@@ -19,6 +19,7 @@ from typing import Tuple
 import numpy as np
 import pytest
 import tensorflow as tf
+import gpflow
 from gpflow import default_float
 
 from markovflow.kernels import Matern32
@@ -237,12 +238,15 @@ def test_linear_function(with_tf_random_seed, batch_shape):
     """Test the linear function scales timepoints correctly."""
     num_time_points = 7
     obs_dim = 3
-    coefficient = 3.1
+    coefficient = gpflow.Parameter(3.1)
 
     time_points = generate_random_time_points(
         expected_range=EXPECTED_RANGE, shape=batch_shape + (num_time_points,)
     )
     linear_mean_function = LinearMeanFunction(coefficient=coefficient, obs_dim=obs_dim)
+    assert linear_mean_function.trainable_parameters == (coefficient,)
+    gpflow.set_trainable(coefficient, False)
+    assert linear_mean_function.trainable_parameters == ()
 
     actual = linear_mean_function(tf.constant(time_points))
     np.testing.assert_allclose(


### PR DESCRIPTION
This PR adds support for users specifying priors on parameters, similarly to in [GPflow](https://gpflow.github.io/GPflow/develop/notebooks/getting_started/parameters_and_their_optimisation.html#Priors). Specifically it makes 2 changes
- All classes defined in markovflow that currently inherit `tf.Module` now inherit `gpflow.Module` (also a child of `tf.Module`), which adds a `trainable_parameters` attribute to all of these classes. Unlike `trainable_variables`, this attribute returns `gpflow.Parameter` objects, which are variables that also have priors.
- Add `log_prior_density` methods to the model base classes, so that `model.log_prior_density()` can be used to compute the log prior density for all trainable parameters with priors. This function is copied from gpflow.

As an added benefit, the classes that inherit `gpflow.Module` inherit some of the useful pretty-printing. e.g. from https://github.com/secondmind-labs/markovflow/blob/7c5ef608340f0a259b8111ab77ea5924c07d7dbb/docs/notebooks/spatio_temporal.py

<details>

```ipython
In [3]: kernel_time
Out[3]: 
<markovflow.kernels.matern.Matern32 object at 0x7f43fb4e3c90>
╒═══════════════════════╤═══════════╤═════════════╤═════════╤═════════════╤═════════╤═════════╤═════════╕
│ name                  │ class     │ transform   │ prior   │ trainable   │ shape   │ dtype   │ value   │
╞═══════════════════════╪═══════════╪═════════════╪═════════╪═════════════╪═════════╪═════════╪═════════╡
│ Matern32._state_mean  │ Parameter │ Identity    │         │ False       │ (2,)    │ float64 │ [0. 0.] │
├───────────────────────┼───────────┼─────────────┼─────────┼─────────────┼─────────┼─────────┼─────────┤
│ Matern32._lengthscale │ Parameter │ Softplus    │         │ True        │ ()      │ float64 │ 2.5     │
├───────────────────────┼───────────┼─────────────┼─────────┼─────────────┼─────────┼─────────┼─────────┤
│ Matern32._variance    │ Parameter │ Softplus    │         │ True        │ ()      │ float64 │ 1.0     │
╘═══════════════════════╧═══════════╧═════════════╧═════════╧═════════════╧═════════╧═════════╧═════════╛

In [5]: model
Out[5]: 
<markovflow.models.spatio_temporal_variational.SpatioTemporalSparseCVI object at 0x7f43fb501cd0>
╒═══════════════════════════════════════════════════════════╤═══════════╤══════════════════╤═════════╤═════════════╤═════════════╤═════════╤═════════════════════╕
│ name                                                      │ class     │ transform        │ prior   │ trainable   │ shape       │ dtype   │ value               │
╞═══════════════════════════════════════════════════════════╪═══════════╪══════════════════╪═════════╪═════════════╪═════════════╪═════════╪═════════════════════╡
│ SpatioTemporalSparseCVI._kernel_space.variance            │ Parameter │ Softplus         │         │ True        │ ()          │ float64 │ 1.0                 │
│ SpatioTemporalSparseCVI._kernel.kernel_space.variance     │           │                  │         │             │             │         │                     │
├───────────────────────────────────────────────────────────┼───────────┼──────────────────┼─────────┼─────────────┼─────────────┼─────────┼─────────────────────┤
│ SpatioTemporalSparseCVI._kernel_space.lengthscales        │ Parameter │ Softplus         │         │ True        │ ()          │ float64 │ 0.5                 │
│ SpatioTemporalSparseCVI._kernel.kernel_space.lengthscales │           │                  │         │             │             │         │                     │
├───────────────────────────────────────────────────────────┼───────────┼──────────────────┼─────────┼─────────────┼─────────────┼─────────┼─────────────────────┤
│ SpatioTemporalSparseCVI._kernel_time._state_mean          │ Parameter │ Identity         │         │ False       │ (2,)        │ float64 │ [0. 0.]             │
│ SpatioTemporalSparseCVI._kernel.kernel_time._state_mean   │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[0]._state_mean   │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[1]._state_mean   │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[2]._state_mean   │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[3]._state_mean   │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[4]._state_mean   │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[5]._state_mean   │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[6]._state_mean   │           │                  │         │             │             │         │                     │
├───────────────────────────────────────────────────────────┼───────────┼──────────────────┼─────────┼─────────────┼─────────────┼─────────┼─────────────────────┤
│ SpatioTemporalSparseCVI._kernel_time._lengthscale         │ Parameter │ Softplus         │         │ True        │ ()          │ float64 │ 2.5                 │
│ SpatioTemporalSparseCVI._kernel.kernel_time._lengthscale  │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[0]._lengthscale  │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[1]._lengthscale  │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[2]._lengthscale  │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[3]._lengthscale  │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[4]._lengthscale  │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[5]._lengthscale  │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[6]._lengthscale  │           │                  │         │             │             │         │                     │
├───────────────────────────────────────────────────────────┼───────────┼──────────────────┼─────────┼─────────────┼─────────────┼─────────┼─────────────────────┤
│ SpatioTemporalSparseCVI._kernel_time._variance            │ Parameter │ Softplus         │         │ True        │ ()          │ float64 │ 1.0                 │
│ SpatioTemporalSparseCVI._kernel.kernel_time._variance     │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[0]._variance     │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[1]._variance     │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[2]._variance     │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[3]._variance     │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[4]._variance     │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[5]._variance     │           │                  │         │             │             │         │                     │
│ SpatioTemporalSparseCVI._kernel._kernels[6]._variance     │           │                  │         │             │             │         │                     │
├───────────────────────────────────────────────────────────┼───────────┼──────────────────┼─────────┼─────────────┼─────────────┼─────────┼─────────────────────┤
│ SpatioTemporalSparseCVI._likelihood.variance              │ Parameter │ Softplus + Shift │         │ True        │ ()          │ float64 │ 0.09999999999999999 │
├───────────────────────────────────────────────────────────┼───────────┼──────────────────┼─────────┼─────────────┼─────────────┼─────────┼─────────────────────┤
│ SpatioTemporalSparseCVI._kernel._state_mean               │ Parameter │ Identity         │         │ False       │ (14,)       │ float64 │ [0., 0., 0....      │
├───────────────────────────────────────────────────────────┼───────────┼──────────────────┼─────────┼─────────────┼─────────────┼─────────┼─────────────────────┤
│ SpatioTemporalSparseCVI.nat1                              │ Parameter │ Identity         │         │ True        │ (8, 28)     │ float64 │ [[0., 0., 0....     │
├───────────────────────────────────────────────────────────┼───────────┼──────────────────┼─────────┼─────────────┼─────────────┼─────────┼─────────────────────┤
│ SpatioTemporalSparseCVI.nat2                              │ Parameter │ Identity         │         │ True        │ (8, 28, 28) │ float64 │ [[[0., 0., 0....    │
╘═══════════════════════════════════════════════════════════╧═══════════╧══════════════════╧═════════╧═════════════╧═════════════╧═════════╧═════════════════════╛
```
</details>